### PR TITLE
Honor `no_default_flags` setting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,8 +509,13 @@ impl Config {
             .opt_level(0)
             .debug(false)
             .warnings(false)
-            .host(&host)
-            .no_default_flags(ndk);
+            .host(&host);
+
+        // Maintain backwards compatibility by setting `no_default_flag`
+        if ndk {
+            c_cfg.no_default_flags(true);
+        }
+
         if !ndk {
             c_cfg.target(&target);
         }
@@ -521,8 +526,13 @@ impl Config {
             .opt_level(0)
             .debug(false)
             .warnings(false)
-            .host(&host)
-            .no_default_flags(ndk);
+            .host(&host);
+
+        // Maintain backwards compatibility by setting `no_default_flag`
+        if ndk {
+            cxx_cfg.no_default_flags(true);
+        }
+
         if !ndk {
             cxx_cfg.target(&target);
         }


### PR DESCRIPTION
Problem: `init_c_cfg` permits the user to set a `cc::Build`
configuration. The setting for `no_default_flags` is always overridden by
`uses_android_sdk`. This prevents a user from building with
`no_default_flags = true`.

Solution: Do not override `no_default_flags` value. In the event
`uses_android_sdk` returns true, continue to set `no_default_flags` to
true. Note that `no_default_flags` defaults to false.

Issue: https://github.com/rust-lang/cmake-rs/issues/188
